### PR TITLE
use electron with browserify

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
   <div id="content"></div>
+  <script>var originalRequire = require;</script>
   <script src="js/index.js"></script>
   <!-- build:remove -->
   <!-- Connect to server process -->

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,11 @@ gulp.task('build-client-bundles', (done) => {
     if (err) done(err)
 
     let tasks = files.map((entry) => {
-      return browserify({ entries: [entry] })
+      return browserify({
+        entries: [entry],
+        ignoreMissing: true,
+        detectGlobals: false
+      })
         .transform('babelify', { presets: [ 'es2015', 'react' ] })
         .bundle()
         .pipe(source(entry))


### PR DESCRIPTION
Browserify will transform require, so you can't require('ipc') in the client js files. Set the options 'ignoreMissing' and 'detectGlobals' which allow browserify to ignore built in modules that eventually get loaded automatically in the electron app. then you can just do require('ipc'), require('fs') or anything in the script directly without any browserify shimming
